### PR TITLE
enable custom state with modals

### DIFF
--- a/__tests__/components/modal/Modal.test.tsx
+++ b/__tests__/components/modal/Modal.test.tsx
@@ -1,21 +1,61 @@
 import { render, fireEvent } from "@testing-library/react";
 import Modal from "components/modal/modal";
+import { useState } from "react";
 
-test("renders ModalTrigger initially and ModalContent after trigger is clicked", () => {
-  const modalTrigger = <button>Open Modal</button>;
-  const modalContent = <div>Test Content</div>;
+describe("Modal", () => {
+  it("renders ModalTrigger initially and ModalContent after trigger is clicked", () => {
+    const modalTrigger = <button>Open Modal</button>;
+    const modalContent = <div>Test Content</div>;
 
-  const { getByRole, queryByText } = render(
-    <Modal modalTrigger={modalTrigger} modalContent={modalContent} />
-  );
+    const { getByRole, queryByText } = render(
+      <Modal modalTrigger={modalTrigger} modalContent={modalContent} />
+    );
 
-  // Check that only the trigger is rendered initially
-  expect(getByRole("button")).toBeDefined();
-  expect(queryByText("Test Content")).toBeNull();
+    // Check that only the trigger is rendered initially
+    expect(getByRole("button")).toBeDefined();
+    expect(queryByText("Test Content")).toBeNull();
 
-  // Simulate a click on the trigger
-  fireEvent.click(getByRole("button"));
+    // Simulate a click on the trigger
+    fireEvent.click(getByRole("button"));
 
-  // Check that the content is rendered after the trigger is clicked
-  expect(queryByText("Test Content")).toBeDefined();
+    // Check that the content is rendered after the trigger is clicked
+    expect(queryByText("Test Content")).toBeDefined();
+  });
+
+  it("Modal accepts external state", () => {
+    const modalTrigger = <button>Open Modal</button>;
+    const modalContent = (
+      setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+    ) => (
+      <div>
+        Test Content
+        <button onClick={() => setIsModalOpen(false)}>Close Modal</button>
+      </div>
+    );
+
+    const ExternalStateWrapper = () => {
+      const [isModalOpen, setIsModalOpen] = useState(false);
+
+      return (
+        <Modal
+          modalTrigger={modalTrigger}
+          modalContent={modalContent(setIsModalOpen)}
+          state={[isModalOpen, setIsModalOpen]}
+        />
+      );
+    };
+
+    const { getByRole, queryByText } = render(<ExternalStateWrapper />);
+
+    expect(getByRole("button", { name: "Open Modal" })).toBeDefined();
+    expect(queryByText("Test Content")).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Open Modal" }));
+
+    expect(queryByText("Test Content")).toBeDefined();
+
+    fireEvent.click(getByRole("button", { name: "Close Modal" }));
+
+    expect(queryByText("Test Content")).toBeNull();
+  });
 });

--- a/__tests__/components/modal/ModalProvider.test.tsx
+++ b/__tests__/components/modal/ModalProvider.test.tsx
@@ -1,0 +1,55 @@
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { ModalProvider, useModal } from "components/modal/ModalProvider";
+import React from "react";
+
+describe("ModalProvider", () => {
+  it("renders children", () => {
+    const { getByText } = render(
+      <ModalProvider>
+        <div>Test Child</div>
+      </ModalProvider>
+    );
+
+    expect(getByText("Test Child")).toBeDefined();
+  });
+
+  it("useModal returns correct initial state", () => {
+    const wrapper = ({ children }: any) => (
+      <ModalProvider>{children}</ModalProvider>
+    );
+
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    expect(result.current.isModalOpen).toBe(false);
+  });
+
+  it("setIsModalOpen changes isModalOpen state", async () => {
+    const wrapper = ({ children }: any) => (
+      <ModalProvider>{children}</ModalProvider>
+    );
+
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    act(() => {
+      result.current.setIsModalOpen(true);
+    });
+
+    expect(result.current.isModalOpen).toBe(true);
+  });
+
+  it("ModalProvider accepts external state", () => {
+    const setIsModalOpen = jest.fn();
+    const externalState = [true, setIsModalOpen] as [
+      boolean,
+      React.Dispatch<React.SetStateAction<boolean>>
+    ];
+    const wrapper = ({ children }: any) => (
+      <ModalProvider state={externalState}>{children}</ModalProvider>
+    );
+
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    expect(result.current.isModalOpen).toBe(true);
+    expect(result.current.setIsModalOpen).toBe(setIsModalOpen);
+  });
+});

--- a/app/components/modal/ModalProvider.tsx
+++ b/app/components/modal/ModalProvider.tsx
@@ -14,10 +14,11 @@ const ModalContext = createContext({
 
 interface ModalContextProps {
   children: React.ReactNode;
+  state?: [boolean, Dispatch<SetStateAction<boolean>>];
 }
 
-export const ModalProvider = ({ children }: ModalContextProps) => {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+export const ModalProvider = ({ children, state }: ModalContextProps) => {
+  const [isModalOpen, setIsModalOpen] = state || useState<boolean>(false);
 
   return (
     <ModalContext.Provider value={{ isModalOpen, setIsModalOpen }}>

--- a/app/components/modal/modal.tsx
+++ b/app/components/modal/modal.tsx
@@ -7,14 +7,16 @@ type Props = {
   modalTrigger: ReactElement<ButtonHTMLAttributes<HTMLButtonElement>, string>;
   modalContent: React.ReactNode;
   hideExitButton?: boolean;
+  state?: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 };
 const Modal = ({
   modalTrigger,
   modalContent,
   hideExitButton = false,
+  state,
 }: Props) => {
   return (
-    <ModalProvider>
+    <ModalProvider state={state}>
       <ModalTrigger trigger={modalTrigger} />
       <ModalContent content={modalContent} hideExitButton={hideExitButton} />
     </ModalProvider>


### PR DESCRIPTION
- you can now pass a custom isModalOpen state to Modal, allowing for more flexibility.

Example:
Clicking a submit button could now also close the modal