### PR TITLE
Test and add types for get guides

### DIFF
--- a/__tests__/__mocks__/mongoHandler.ts
+++ b/__tests__/__mocks__/mongoHandler.ts
@@ -9,9 +9,10 @@ import {
   Review,
   ReviewedFeedbackDocument,
   ReviewedFeedbackType,
+  Vote,
 } from "../../app/models/review";
 import { Return, ReturnDocument, ReturnType } from "../../app/models/return";
-import { Guide, GuideType } from "../../app/models/guide";
+import { Guide, GuideDocument, GuideType } from "../../app/models/guide";
 
 jest.mock("../../app/utils/mongoose-connector", () => ({
   connectToDatabase: jest.fn(),
@@ -60,7 +61,7 @@ export const createDummyUser = async (
   return await User.create(dummyUser);
 };
 
-export const createDummyGuide = async (): Promise<GuideType> => {
+export const createDummyGuide = async (): Promise<GuideDocument> => {
   const dummyGuide: Partial<GuideType> = {
     category: faker.lorem.word(),
     title: faker.lorem.sentence(),
@@ -84,7 +85,7 @@ export const createDummyGuide = async (): Promise<GuideType> => {
 
 export const createDummyReturn = async (
   user?: UserDocument,
-  guide?: GuideType
+  guide?: GuideDocument
 ): Promise<ReturnDocument> => {
   const dummyReturn: Partial<ReturnType> = {
     projectUrl: faker.internet.url(),
@@ -102,7 +103,7 @@ export const createDummyReturn = async (
 
 export const createDummyFeedback = async (
   owner?: UserDocument,
-  guide?: GuideType,
+  guide?: GuideDocument,
   userReturn?: ReturnType,
   fail?: boolean
 ): Promise<FeedbackDocument> => {
@@ -117,7 +118,7 @@ export const createDummyFeedback = async (
     return: userReturn?._id ?? new mongoose.Types.ObjectId(),
     owner: owner?._id ?? new mongoose.Types.ObjectId(),
     comment: faker.lorem.sentence(),
-    vote: fail ? "no pass" : "pass",
+    vote: fail ? Vote.NO_PASS : Vote.PASS,
     createdAt: new Date(),
   };
 
@@ -126,21 +127,18 @@ export const createDummyFeedback = async (
 
 export const createDummyReview = async (
   owner?: UserDocument,
-  guide?: GuideType,
+  guide?: GuideDocument,
   userReturn?: ReturnType,
-  reviewer?: UserDocument
+  reviewer?: UserDocument,
+  grade?: number
 ): Promise<ReviewedFeedbackDocument> => {
-  const votes: ("no pass" | "pass" | "recommend to gallery")[] = [
-    "no pass",
-    "pass",
-    "recommend to gallery",
-  ];
+  const votes = [Vote.NO_PASS, Vote.PASS, Vote.RECOMMEND_TO_GALLERY];
 
   const dummyReview: Partial<ReviewedFeedbackType> = {
     guide: guide?._id ?? new mongoose.Types.ObjectId(),
     return: userReturn?._id ?? new mongoose.Types.ObjectId(),
     reviewer: reviewer?._id ?? new mongoose.Types.ObjectId(),
-    grade: faker.number.int(10),
+    grade: grade ?? faker.number.int(10),
     owner: owner?._id ?? new mongoose.Types.ObjectId(),
     comment: faker.lorem.sentence(),
     vote: votes[Math.floor(Math.random() * votes.length)],

--- a/__tests__/mongoQueries/getGuides.test.ts
+++ b/__tests__/mongoQueries/getGuides.test.ts
@@ -2,6 +2,7 @@ import {
   clearDatabase,
   closeDatabase,
   connect,
+  createDummyFeedback,
   createDummyGuide,
   createDummyReturn,
   createDummyReview,
@@ -13,16 +14,19 @@ import { Types } from "mongoose";
 // for type checking
 function isGuideInfo(obj: any): obj is GuideInfo {
   return (
-    typeof obj.category === "string" &&
-    typeof obj.description === "string" &&
-    typeof obj.isReturned === "boolean" &&
-    typeof obj.order === "number" &&
-    typeof obj.title === "string" &&
+    typeof obj.returnStatus === "string" &&
     Array.isArray(obj.returnsSubmitted) &&
-    Array.isArray(obj.reviewsGiven) &&
-    typeof obj.numberOfReviewsGiven === "number" &&
+    Array.isArray(obj.feedbackReceived) &&
+    typeof obj.feedbackToGiveStatus === "string" &&
+    Array.isArray(obj.availableForFeedback) &&
+    Array.isArray(obj.feedbackGiven) &&
+    typeof obj.feedbackGivenCount === "number" &&
+    typeof obj.reviewsReceivedStatus === "string" &&
     Array.isArray(obj.reviewsReceived) &&
-    Array.isArray(obj.returnsToReview) &&
+    Array.isArray(obj.reviewsReceivedGrades) &&
+    typeof obj.reviewsToGiveStatus === "string" &&
+    Array.isArray(obj.reviewsGiven) &&
+    Array.isArray(obj.availableToReview) &&
     obj._id instanceof Types.ObjectId
   );
 }
@@ -34,47 +38,82 @@ describe("getGuides", () => {
 
   afterAll(async () => await closeDatabase());
 
-  it("gets guides", async () => {
+  it("gets returns correct data", async () => {
     const user = await createDummyUser();
+    const reviewer = await createDummyUser(); // create a user to be the reviewer
 
     const guide = await createDummyGuide();
 
     const userReturn = await createDummyReturn(user, guide);
+    const userReturn2 = await createDummyReturn(undefined, guide);
+    const userReturn3 = await createDummyReturn(user, guide);
 
-    const review = await createDummyReview(user, guide, userReturn);
+    const review = await createDummyReview(user, guide, userReturn, reviewer);
+    const review2 = await createDummyReview(undefined, guide, userReturn, user);
+    const review3 = await createDummyReview(undefined, guide, userReturn, user);
+
+    const feedback = await createDummyFeedback(undefined, guide, userReturn);
+    const feedback2 = await createDummyFeedback(undefined, guide, userReturn);
+    const feedback3 = await createDummyFeedback(user, guide, userReturn);
 
     const guides = await getGuides(user);
 
     if (guides) {
       expect(guides[0]).toMatchObject({
-        category: guide.category,
+        _id: expect.any(Types.ObjectId),
         title: guide.title,
         description: guide.description,
+        category: guide.category,
+        order: guide.order,
         module: {
           title: guide.module.title,
           number: guide.module.number,
         },
-        order: guide.order,
-        numberOfReviewsGiven: 1,
-        isReturned: true,
+        returnStatus: expect.any(String),
+        feedbackToGiveStatus: expect.any(String),
+        feedbackGivenCount: expect.any(Number),
+        reviewsReceivedStatus: expect.stringContaining("Reviews received"), // in practice users wouldnt review their own returns
+        reviewsReceivedGrades: expect.arrayContaining([review.grade]),
+        reviewsToGiveStatus: expect.any(String),
       });
-      expect(guides[0].returnsSubmitted[0]).toMatchObject({
-        projectUrl: userReturn.projectUrl,
-        liveVersion: userReturn.liveVersion,
-        pictureUrl: userReturn.pictureUrl,
-        projectName: userReturn.projectName,
-        comment: userReturn.comment,
-      });
-      expect(guides[0].reviewsGiven[0]).toMatchObject({
-        guide: review.guide,
-        return: review.return,
-        owner: review.owner,
-        comment: review.comment,
-        vote: review.vote,
-      });
-      expect(guides[0].reviewsReceived[0]).toBeUndefined();
+      expect(guides[0].returnsSubmitted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(userReturn.toObject()),
+          expect.objectContaining(userReturn3.toObject()),
+        ])
+      );
+      expect(guides[0].reviewsReceived).toEqual(
+        expect.arrayContaining([expect.objectContaining(review.toObject())])
+      );
+      expect(guides[0].reviewsReceivedGrades).toEqual(
+        expect.arrayContaining([review.grade])
+      );
+      expect(guides[0].reviewsGiven).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(review2.toObject()),
+          expect.objectContaining(review3.toObject()),
+        ])
+      );
+      expect(guides[0].availableToReview).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(feedback.toObject()),
+          expect.objectContaining(feedback2.toObject()),
+        ])
+      );
+      expect(guides[0].feedbackReceived).toEqual(
+        expect.arrayContaining([expect.objectContaining(feedback.toObject())])
+      );
+      expect(guides[0].feedbackGiven).toEqual(
+        expect.arrayContaining([expect.objectContaining(feedback3.toObject())])
+      );
+      expect(guides[0].availableForFeedback).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(userReturn2.toObject()),
+        ])
+      );
     }
   });
+
   it("returns GuideInfo[]", async () => {
     const user = await createDummyUser();
 
@@ -105,83 +144,28 @@ describe("getGuides", () => {
 
     expect(guides).toBeNull();
   });
-  it("returns correct Reviews in reviewsReceived", async () => {
+  it("sets the correct returnStatus", async () => {
     const user = await createDummyUser();
 
     const guide = await createDummyGuide();
 
     const userReturn = await createDummyReturn(user, guide);
 
-    await createDummyReview(user, guide, userReturn);
-    const review2 = await createDummyReview(undefined, guide, userReturn);
-
     const guides = await getGuides(user);
 
     if (guides) {
-      expect(guides[0].reviewsReceived[0]._id).toEqual(review2._id);
-      expect(guides[0].reviewsReceived.length).toBe(1);
+      expect(guides[0].returnStatus).toEqual("Returned");
     }
   });
-  it("returns correct Returns in returnsToReview", async () => {
+  it("sets the correct returnStatus when no returns are submitted", async () => {
     const user = await createDummyUser();
 
     const guide = await createDummyGuide();
 
-    const userReturn = await createDummyReturn(user, guide);
-
-    await createDummyReview(user, guide, userReturn);
-    const userReturn2 = await createDummyReturn(undefined, guide);
-
     const guides = await getGuides(user);
 
     if (guides) {
-      expect(guides[0].returnsToReview[0]._id).toEqual(userReturn2._id);
-      expect(guides[0].returnsToReview.length).toBe(1);
-    }
-  });
-  it("returns correct number of reviewsGiven", async () => {
-    const user = await createDummyUser();
-
-    const guide = await createDummyGuide();
-
-    const userReturn = await createDummyReturn(user, guide);
-
-    await createDummyReview(user, guide, userReturn);
-    await createDummyReview(user, guide, userReturn);
-
-    const guides = await getGuides(user);
-
-    if (guides) {
-      expect(guides[0].numberOfReviewsGiven).toBe(2);
-    }
-  });
-  it("returns correct returnsSubmitted", async () => {
-    const user = await createDummyUser();
-
-    const guide1 = await createDummyGuide();
-    const guide2 = await createDummyGuide();
-
-    const userReturn = await createDummyReturn(user, guide1);
-    const userReturn2 = await createDummyReturn(user, guide1);
-    const userReturn3 = await createDummyReturn(user, guide2);
-
-    await createDummyReturn(undefined, guide1);
-
-    const guides = await getGuides(user);
-
-    if (guides) {
-      expect(guides.length).toBe(2);
-      guides.forEach((guide) => {
-        if (guide._id.equals(guide2._id)) {
-          expect(guide.returnsSubmitted.length).toBe(1);
-          expect(guide.returnsSubmitted[0]._id).toEqual(userReturn3._id);
-        } else if (guide._id.equals(guide1._id)) {
-          expect(guide.returnsSubmitted.length).toBe(2);
-          expect(guide.returnsSubmitted[0]._id).toEqual(userReturn._id);
-        } else {
-          expect(false).toBe(true);
-        }
-      });
+      expect(guides[0].returnStatus).toEqual("Not returned");
     }
   });
 });

--- a/__tests__/mongoQueries/getGuides.test.ts
+++ b/__tests__/mongoQueries/getGuides.test.ts
@@ -7,9 +7,10 @@ import {
   createDummyReturn,
   createDummyReview,
   createDummyUser,
-} from "./mongoHandler";
-import { GuideInfo, getGuides } from "../../app/guides/query";
+} from "../__mocks__/mongoHandler";
+import { getGuides } from "../../app/guides/query";
 import { Types } from "mongoose";
+import { GuideInfo } from "../../app/guides/types";
 
 // for type checking
 function isGuideInfo(obj: any): obj is GuideInfo {
@@ -55,13 +56,13 @@ describe("getGuides", () => {
     if (guides) {
       expect(guides[0]).toMatchObject({
         _id: expect.any(Types.ObjectId),
-        title: guide.title,
-        description: guide.description,
-        category: guide.category,
-        order: guide.order,
+        title: guides[0].title,
+        description: guides[0].description,
+        category: guides[0].category,
+        order: guides[0].order,
         module: {
-          title: guide.module.title,
-          number: guide.module.number,
+          title: guides[0].module.title,
+          number: guides[0].module.number,
         },
       });
       expect(guides[0].returnsSubmitted).toEqual(

--- a/__tests__/mongoQueries/getGuides.test.ts
+++ b/__tests__/mongoQueries/getGuides.test.ts
@@ -14,17 +14,11 @@ import { Types } from "mongoose";
 // for type checking
 function isGuideInfo(obj: any): obj is GuideInfo {
   return (
-    typeof obj.returnStatus === "string" &&
     Array.isArray(obj.returnsSubmitted) &&
     Array.isArray(obj.feedbackReceived) &&
-    typeof obj.feedbackToGiveStatus === "string" &&
     Array.isArray(obj.availableForFeedback) &&
     Array.isArray(obj.feedbackGiven) &&
-    typeof obj.feedbackGivenCount === "number" &&
-    typeof obj.reviewsReceivedStatus === "string" &&
     Array.isArray(obj.reviewsReceived) &&
-    Array.isArray(obj.reviewsReceivedGrades) &&
-    typeof obj.reviewsToGiveStatus === "string" &&
     Array.isArray(obj.reviewsGiven) &&
     Array.isArray(obj.availableToReview) &&
     obj._id instanceof Types.ObjectId
@@ -69,12 +63,6 @@ describe("getGuides", () => {
           title: guide.module.title,
           number: guide.module.number,
         },
-        returnStatus: expect.any(String),
-        feedbackToGiveStatus: expect.any(String),
-        feedbackGivenCount: expect.any(Number),
-        reviewsReceivedStatus: expect.stringContaining("Reviews received"), // in practice users wouldnt review their own returns
-        reviewsReceivedGrades: expect.arrayContaining([review.grade]),
-        reviewsToGiveStatus: expect.any(String),
       });
       expect(guides[0].returnsSubmitted).toEqual(
         expect.arrayContaining([
@@ -85,9 +73,7 @@ describe("getGuides", () => {
       expect(guides[0].reviewsReceived).toEqual(
         expect.arrayContaining([expect.objectContaining(review.toObject())])
       );
-      expect(guides[0].reviewsReceivedGrades).toEqual(
-        expect.arrayContaining([review.grade])
-      );
+
       expect(guides[0].reviewsGiven).toEqual(
         expect.arrayContaining([
           expect.objectContaining(review2.toObject()),
@@ -143,29 +129,5 @@ describe("getGuides", () => {
     const guides = await getGuides(null);
 
     expect(guides).toBeNull();
-  });
-  it("sets the correct returnStatus", async () => {
-    const user = await createDummyUser();
-
-    const guide = await createDummyGuide();
-
-    const userReturn = await createDummyReturn(user, guide);
-
-    const guides = await getGuides(user);
-
-    if (guides) {
-      expect(guides[0].returnStatus).toEqual("Returned");
-    }
-  });
-  it("sets the correct returnStatus when no returns are submitted", async () => {
-    const user = await createDummyUser();
-
-    const guide = await createDummyGuide();
-
-    const guides = await getGuides(user);
-
-    if (guides) {
-      expect(guides[0].returnStatus).toEqual("Not returned");
-    }
   });
 });

--- a/__tests__/mongoQueries/mongoHandler.ts
+++ b/__tests__/mongoQueries/mongoHandler.ts
@@ -103,7 +103,8 @@ export const createDummyReturn = async (
 export const createDummyFeedback = async (
   owner?: UserDocument,
   guide?: GuideType,
-  userReturn?: ReturnType
+  userReturn?: ReturnType,
+  fail?: boolean
 ): Promise<FeedbackDocument> => {
   const votes: ("no pass" | "pass" | "recommend to gallery")[] = [
     "no pass",
@@ -116,7 +117,7 @@ export const createDummyFeedback = async (
     return: userReturn?._id ?? new mongoose.Types.ObjectId(),
     owner: owner?._id ?? new mongoose.Types.ObjectId(),
     comment: faker.lorem.sentence(),
-    vote: votes[Math.floor(Math.random() * votes.length)],
+    vote: fail ? "no pass" : "pass",
     createdAt: new Date(),
   };
 

--- a/__tests__/mongoQueries/mongoHandler.ts
+++ b/__tests__/mongoQueries/mongoHandler.ts
@@ -3,8 +3,14 @@ import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { User, UserDocument, UserInfo } from "../../app/models/user";
 import { faker } from "@faker-js/faker";
-import { Review, ReviewType } from "../../app/models/review";
-import { Return, ReturnType } from "../../app/models/return";
+import {
+  FeedbackDocument,
+  FeedbackType,
+  Review,
+  ReviewedFeedbackDocument,
+  ReviewedFeedbackType,
+} from "../../app/models/review";
+import { Return, ReturnDocument, ReturnType } from "../../app/models/return";
 import { Guide, GuideType } from "../../app/models/guide";
 
 jest.mock("../../app/utils/mongoose-connector", () => ({
@@ -79,7 +85,7 @@ export const createDummyGuide = async (): Promise<GuideType> => {
 export const createDummyReturn = async (
   user?: UserDocument,
   guide?: GuideType
-): Promise<ReturnType> => {
+): Promise<ReturnDocument> => {
   const dummyReturn: Partial<ReturnType> = {
     projectUrl: faker.internet.url(),
     liveVersion: faker.internet.url(),
@@ -94,21 +100,47 @@ export const createDummyReturn = async (
   return await Return.create(dummyReturn);
 };
 
-export const createDummyReview = async (
-  user?: UserDocument,
+export const createDummyFeedback = async (
+  owner?: UserDocument,
   guide?: GuideType,
   userReturn?: ReturnType
-): Promise<ReviewType> => {
+): Promise<FeedbackDocument> => {
   const votes: ("no pass" | "pass" | "recommend to gallery")[] = [
     "no pass",
     "pass",
     "recommend to gallery",
   ];
 
-  const dummyReview: Partial<ReviewType> = {
+  const dummyReview: Partial<FeedbackType> = {
     guide: guide?._id ?? new mongoose.Types.ObjectId(),
     return: userReturn?._id ?? new mongoose.Types.ObjectId(),
-    owner: user?._id ?? new mongoose.Types.ObjectId(),
+    owner: owner?._id ?? new mongoose.Types.ObjectId(),
+    comment: faker.lorem.sentence(),
+    vote: votes[Math.floor(Math.random() * votes.length)],
+    createdAt: new Date(),
+  };
+
+  return await Review.create(dummyReview);
+};
+
+export const createDummyReview = async (
+  owner?: UserDocument,
+  guide?: GuideType,
+  userReturn?: ReturnType,
+  reviewer?: UserDocument
+): Promise<ReviewedFeedbackDocument> => {
+  const votes: ("no pass" | "pass" | "recommend to gallery")[] = [
+    "no pass",
+    "pass",
+    "recommend to gallery",
+  ];
+
+  const dummyReview: Partial<ReviewedFeedbackType> = {
+    guide: guide?._id ?? new mongoose.Types.ObjectId(),
+    return: userReturn?._id ?? new mongoose.Types.ObjectId(),
+    reviewer: reviewer?._id ?? new mongoose.Types.ObjectId(),
+    grade: faker.number.int(10),
+    owner: owner?._id ?? new mongoose.Types.ObjectId(),
     comment: faker.lorem.sentence(),
     vote: votes[Math.floor(Math.random() * votes.length)],
     createdAt: new Date(),

--- a/__tests__/utils/guideUtils.test.ts
+++ b/__tests__/utils/guideUtils.test.ts
@@ -1,0 +1,244 @@
+// utils.test.ts
+import {
+  FeedbackStatus,
+  ReturnStatus,
+  ReviewsGivenStatus,
+  ReviewsReceivedStatus,
+} from "../../app/guides/types";
+import {
+  calculateFeedbackStatus,
+  calculateReturnStatus,
+  calculateReviewGivenStatus,
+  calculateReviewsReceivedStatus,
+  calculateReviewScore,
+} from "../../app/guides/utils";
+import {
+  clearDatabase,
+  closeDatabase,
+  connect,
+  createDummyFeedback,
+  createDummyGuide,
+  createDummyReturn,
+  createDummyReview,
+  createDummyUser,
+} from "../__mocks__/mongoHandler";
+
+describe("calculateReturnStatus", () => {
+  beforeAll(async () => await connect());
+
+  afterEach(async () => await clearDatabase());
+
+  afterAll(async () => await closeDatabase());
+
+  it("should return NOT_RETURNED if no guides are returned", () => {
+    const result = calculateReturnStatus([], []);
+    expect(result).toBe(ReturnStatus.NOT_RETURNED);
+  });
+
+  it("should return AWAITING_FEEDBACK if a guide is returned but no feedback is given on that guide", async () => {
+    const guide1 = await createDummyGuide();
+
+    const user = await createDummyUser();
+
+    const return1 = await createDummyReturn(user, guide1);
+    const return2 = await createDummyReturn(user, guide1);
+
+    const feedbackGuide1 = await createDummyFeedback(
+      undefined,
+      guide1,
+      return1
+    );
+    const feedbackGuide2 = await createDummyFeedback(
+      undefined,
+      guide1,
+      return1
+    );
+
+    expect(
+      calculateReturnStatus(
+        [return1, return2],
+        [feedbackGuide1, feedbackGuide2]
+      )
+    ).toBe(ReturnStatus.AWAITING_FEEDBACK);
+  });
+
+  it("should return FAILED if a guide is returned and feedback is given on that guide but the feedback is 'no pass'", async () => {
+    const guide1 = await createDummyGuide();
+
+    const user = await createDummyUser();
+
+    const return1 = await createDummyReturn(user, guide1);
+
+    const feedbackGuide1 = await createDummyFeedback(
+      undefined,
+      guide1,
+      return1,
+      true
+    );
+
+    expect(calculateReturnStatus([return1], [feedbackGuide1])).toBe(
+      ReturnStatus.FAILED
+    );
+  });
+
+  it("should return PASSED if a guide is returned and at least 2 feedback is given on that guide and the feedback is 'pass'", async () => {
+    const guide1 = await createDummyGuide();
+
+    const user = await createDummyUser();
+
+    const return1 = await createDummyReturn(user, guide1);
+
+    const feedbackGuide1 = await createDummyFeedback(
+      undefined,
+      guide1,
+      return1,
+      false
+    );
+    const feedbackGuide2 = await createDummyFeedback(
+      undefined,
+      guide1,
+      return1,
+      false
+    );
+    expect(
+      calculateReturnStatus([return1], [feedbackGuide1, feedbackGuide2])
+    ).toBe(ReturnStatus.PASSED);
+  });
+
+  // describe("calculateFeedbackStatus", () => {
+  //   it("should return AWAITING_PROJECTS if no feedback is given and no projects are available", () => {
+  //     const result = calculateFeedbackStatus([], []);
+  //     expect(result).toBe(FeedbackStatus.AWAITING_PROJECTS);
+  //   });
+
+  //   // Add more test cases here...
+});
+
+describe("calculateFeedbackStatus", () => {
+  beforeAll(async () => await connect());
+
+  afterEach(async () => await clearDatabase());
+
+  afterAll(async () => await closeDatabase());
+
+  it("should return AWAITING_PROJECTS if no feedback is given and no projects are available", () => {
+    const result = calculateFeedbackStatus([], []);
+    expect(result).toBe(FeedbackStatus.AWAITING_PROJECTS);
+  });
+
+  it("should return NEED_TO_PROVIDE_FEEDBACK if less than 2 feedbacks are given and projects are available", async () => {
+    const feedback1 = await createDummyFeedback();
+    const return1 = await createDummyReturn();
+
+    const result = calculateFeedbackStatus([feedback1], [return1]);
+    expect(result).toBe(FeedbackStatus.NEED_TO_PROVIDE_FEEDBACK);
+  });
+
+  it("should return FEEDBACK_GIVEN if at least 2 feedbacks are given", async () => {
+    const feedback1 = await createDummyFeedback();
+    const feedback2 = await createDummyFeedback();
+    const return1 = await createDummyReturn();
+
+    const result = calculateFeedbackStatus([feedback1, feedback2], [return1]);
+    expect(result).toBe(FeedbackStatus.FEEDBACK_GIVEN);
+  });
+});
+
+describe("calculateReviewsReceivedStatus", () => {
+  beforeAll(async () => await connect());
+
+  afterEach(async () => await clearDatabase());
+
+  afterAll(async () => await closeDatabase());
+
+  it("should return AWAITING_REVIEWS if less than 2 reviews are received", async () => {
+    const review1 = await createDummyReview();
+
+    const result = calculateReviewsReceivedStatus([review1]);
+
+    expect(result).toBe(ReviewsReceivedStatus.AWAITING_REVIEWS);
+  });
+
+  it("should return REVIEWS_RECEIVED if at least 2 reviews are received", async () => {
+    const review1 = await createDummyReview();
+
+    const review2 = await createDummyReview();
+
+    const result = calculateReviewsReceivedStatus([review1, review2]);
+    expect(result).toBe(ReviewsReceivedStatus.REVIEWS_RECEIVED);
+  });
+});
+
+describe("calculateReviewScore", () => {
+  beforeAll(async () => await connect());
+
+  afterEach(async () => await clearDatabase());
+
+  afterAll(async () => await closeDatabase());
+
+  it("should return undefined if no reviews are received", async () => {
+    const result = calculateReviewScore([]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined if 1 review is received", async () => {
+    const review1 = await createDummyReview();
+    const result = calculateReviewScore([review1]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the average of the two highest reviews", async () => {
+    const review1 = await createDummyReview(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      5
+    );
+    const review2 = await createDummyReview(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      9
+    );
+    const review3 = await createDummyReview(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      6
+    );
+
+    const result = calculateReviewScore([review1, review2, review3]);
+    expect(result).toBe((review2.grade + review3.grade) / 2);
+  });
+});
+
+describe("calculateReviewGivenStatus", () => {
+  beforeAll(async () => await connect());
+
+  afterEach(async () => await clearDatabase());
+
+  afterAll(async () => await closeDatabase());
+
+  it("should return AWAITING_FEEDBACK if no reviews are given and no projects are available", async () => {
+    const result = calculateReviewGivenStatus([], []);
+    expect(result).toBe(ReviewsGivenStatus.AWAITING_FEEDBACK);
+  });
+
+  it("should return NEED_TO_REVIEW if no reviews are given and projects are available", async () => {
+    const return1 = await createDummyReturn();
+    const result = calculateReviewGivenStatus([], [return1]);
+    expect(result).toBe(ReviewsGivenStatus.NEED_TO_REVIEW);
+  });
+
+  it("should return REVIEWS_GIVEN if at least 2 reviews are given", async () => {
+    const review1 = await createDummyReview();
+    const review2 = await createDummyReview();
+    const return1 = await createDummyReturn();
+
+    const result = calculateReviewGivenStatus([review1, review2], [return1]);
+    expect(result).toBe(ReviewsGivenStatus.REVIEWS_GIVEN);
+  });
+});

--- a/app/components/guideCard/guideStatus.tsx
+++ b/app/components/guideCard/guideStatus.tsx
@@ -1,0 +1,27 @@
+// this will be used to display the status of the guide
+
+// For each guide we have these "states"
+
+// Return statues
+// - Guide not returned
+// - Guide returned and not reviewed
+// - Guide returned and passed
+// - Guide returned and failed
+
+enum ReturnStatus {
+  NOT_RETURNED = "Guide not returned",
+  RETURNED_NOT_REVIEWED = "Guide returned and not reviewed",
+  RETURNED_PASSED = "Guide returned and passed",
+  RETURNED_FAILED = "Guide returned and failed",
+}
+
+enum ReviewStatus {
+  NO_REVIEW = "Review not given",
+  ONE_REVIEW = "1 Review given",
+  TWO_OR_MORE_REVIEWS = "2 or more Reviews given",
+}
+
+// Review statues
+// - Review not given
+// - 1 Review given
+// - 2 or more Reviews given

--- a/app/components/guideCard/guideStatus.tsx
+++ b/app/components/guideCard/guideStatus.tsx
@@ -2,26 +2,25 @@
 
 // For each guide we have these "states"
 
-// Return statues
-// - Guide not returned
-// - Guide returned and not reviewed
-// - Guide returned and passed
-// - Guide returned and failed
-
-enum ReturnStatus {
+export enum ReturnStatus {
   NOT_RETURNED = "Guide not returned",
-  RETURNED_NOT_REVIEWED = "Guide returned and not reviewed",
+  RETURNED_AWAITING_REVIEW = "Guide returned and awaiting review",
   RETURNED_PASSED = "Guide returned and passed",
   RETURNED_FAILED = "Guide returned and failed",
 }
 
-enum ReviewStatus {
-  NO_REVIEW = "Review not given",
-  ONE_REVIEW = "1 Review given",
-  TWO_OR_MORE_REVIEWS = "2 or more Reviews given",
+export enum FeedbackToGiveStatus {
+  NO_FEEDBACK_TO_GIVE = "No feedback to give",
+  FEEDBACK_TO_GIVE = "Feedback to give",
 }
 
-// Review statues
-// - Review not given
-// - 1 Review given
-// - 2 or more Reviews given
+export enum ReviewsReceivedStatus {
+  NO_REVIEW = "No reviews received",
+  ONE_REVIEW = "1 Review received",
+  TWO_OR_MORE_REVIEWS = "Reviews received",
+}
+
+export const enum ReviewsToGiveStatus {
+  NO_REVIEWS_TO_GIVE = "No reviews to give",
+  REVIEWS_TO_GIVE = "Reviews to give",
+}

--- a/app/components/guideCard/index.tsx
+++ b/app/components/guideCard/index.tsx
@@ -12,34 +12,30 @@ import {
   InfoWrapper,
   Review,
 } from "./style";
+import { GuideInfoWithLink } from "../../guides/query";
 
-type GuideCardProps = {
-  guideNr: number;
-  name: string;
-  status: string;
-  forReturn: string;
-};
-
-const GuideCard = ({ guideNr, name, status, forReturn }: GuideCardProps) => {
+const GuideCard = ({ guide }: { guide: GuideInfoWithLink }) => {
   const ModalTrigger = (
     <StatusWrapper>
       <Review>
-        <Status>{status}</Status>
+        <Status>
+          {guide.returnsSubmitted ? "Guide returned" : "Guide not returned"}
+        </Status>
       </Review>
     </StatusWrapper>
   );
 
   // todo: implement review modal
   const ModalContent = <div>PLACEHOLDER</div>;
-
+  console.log(guide);
   return (
     <>
       <CardWrapper>
         <InfoWrapper>
-          <StyledLink href={forReturn}>
+          <StyledLink href={guide.individualGuideLink}>
             <Info>
-              <GuideNr>GUIDE {guideNr}</GuideNr>
-              <Name>{name}</Name>
+              <GuideNr>{`GUIDE ${guide.order}`}</GuideNr>
+              <Name>{guide.title}</Name>
             </Info>
           </StyledLink>
         </InfoWrapper>

--- a/app/components/guideCard/index.tsx
+++ b/app/components/guideCard/index.tsx
@@ -27,7 +27,6 @@ const GuideCard = ({ guide }: { guide: GuideInfoWithLink }) => {
 
   // todo: implement review modal
   const ModalContent = <div>PLACEHOLDER</div>;
-  console.log(guide);
   return (
     <>
       <CardWrapper>

--- a/app/components/modal/ModalContent.tsx
+++ b/app/components/modal/ModalContent.tsx
@@ -4,8 +4,6 @@ import { useModal } from "./ModalProvider";
 import { ButtonWrapper, ContentWrapper, ModalWrapper } from "./style";
 import { useEffect } from "react";
 
-const body = document.querySelector("body");
-
 export const ModalContent = ({
   content,
   hideExitButton = false,
@@ -16,10 +14,13 @@ export const ModalContent = ({
   const { isModalOpen, setIsModalOpen } = useModal();
 
   useEffect(() => {
-    if (isModalOpen) {
-      body!.style.overflow = "hidden";
-    } else {
-      body!.style.overflow = "auto";
+    if (typeof document !== "undefined") {
+      const body = document.querySelector("body");
+      if (isModalOpen) {
+        body!.style.overflow = "hidden";
+      } else {
+        body!.style.overflow = "auto";
+      }
     }
   }, [isModalOpen]);
 

--- a/app/guides/Guides.tsx
+++ b/app/guides/Guides.tsx
@@ -2,10 +2,9 @@
 import GuidesClient from "./guidesClient";
 
 import React, { useMemo, useState } from "react";
-import { Module } from "../utils/types";
 import { Container } from "./style";
 import { Dropdown } from "components/dropdown/Dropdown";
-import { GuideInfoWithLink } from "./query";
+import { GuideInfoWithLink, Module } from "./types";
 
 export const Guides = ({
   fetchedGuides,

--- a/app/guides/guidesClient/index.tsx
+++ b/app/guides/guidesClient/index.tsx
@@ -1,14 +1,13 @@
 import GuideCard from "../../components/guideCard";
 
 import { GuideContainer } from "../style";
-import { GuideInfoWithLink } from "../query";
+import { GuideInfoWithLink } from "../types";
 
 type Props = {
   fetchedGuides: GuideInfoWithLink[];
 };
 
 const GuidesClient = ({ fetchedGuides }: Props) => {
-  console.log(fetchedGuides);
   return (
     <GuideContainer>
       {fetchedGuides.map((guide, index) => {

--- a/app/guides/guidesClient/index.tsx
+++ b/app/guides/guidesClient/index.tsx
@@ -8,17 +8,12 @@ type Props = {
 };
 
 const GuidesClient = ({ fetchedGuides }: Props) => {
+  console.log(fetchedGuides);
   return (
     <GuideContainer>
-      {fetchedGuides.map((guide, index) => (
-        <GuideCard
-          forReturn={guide.individualGuideLink}
-          key={guide.individualGuideLink}
-          guideNr={index + 1}
-          name={guide.title}
-          status="Guide not Returned"
-        />
-      ))}
+      {fetchedGuides.map((guide, index) => {
+        return <GuideCard guide={guide} key={index} />;
+      })}
     </GuideContainer>
   );
 };

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,11 +1,11 @@
 import { GuideInfo, GuideInfoWithLink, getGuides } from "./query";
-import { UserWithIdType } from "../models/user";
+import { UserDocument, UserWithIdType } from "../models/user";
 
 import { auth } from "../../auth";
 import { Guides } from "./Guides";
 
 const GuidesPage = async () => {
-  const session = (await auth()) as unknown as UserWithIdType;
+  const session = (await auth()) as unknown as UserDocument;
   if (!session) return null;
 
   const fetchingGuides: GuideInfo[] = (await getGuides(session)) || [];

--- a/app/guides/query.tsx
+++ b/app/guides/query.tsx
@@ -1,38 +1,9 @@
 import { connectToDatabase } from "../utils/mongoose-connector";
-import { Guide, ModuleType } from "../models/guide";
+import { Guide } from "../models/guide";
 import { ObjectId } from "mongodb";
 import { UserDocument } from "../models/user";
-import { ReturnType } from "../models/return";
-import { FeedbackDocument, ReviewedFeedbackDocument } from "../models/review";
-import { PipelineStage, Types } from "mongoose";
-
-export type GuideInfo = {
-  _id: Types.ObjectId;
-  title: string;
-  description: string;
-  category: string;
-  order: number;
-  module: ModuleType;
-
-  // this user's project returns
-  returnsSubmitted: ReturnType[];
-  feedbackReceived: FeedbackDocument[];
-
-  // giving feedback on others' returns
-  availableForFeedback: ReturnType[];
-  feedbackGiven: FeedbackDocument[];
-
-  // reviews received by others on feedback given by this user
-  reviewsReceived: ReviewedFeedbackDocument[];
-
-  // reviewing others' feedback
-  reviewsGiven: ReviewedFeedbackDocument[];
-  availableToReview: ReturnType[];
-};
-
-export type GuideInfoWithLink = GuideInfo & {
-  individualGuideLink: string;
-};
+import { PipelineStage } from "mongoose";
+import { GuideInfo } from "./types";
 
 export async function getGuides(
   user: UserDocument | null

--- a/app/guides/query.tsx
+++ b/app/guides/query.tsx
@@ -6,29 +6,6 @@ import { ReturnType } from "../models/return";
 import { FeedbackDocument, ReviewedFeedbackDocument } from "../models/review";
 import { PipelineStage, Types } from "mongoose";
 
-enum ReturnStatus {
-  NOT_RETURNED = "Guide not returned",
-  RETURNED_AWAITING_REVIEW = "Guide returned and awaiting review",
-  RETURNED_PASSED = "Guide returned and passed",
-  RETURNED_FAILED = "Guide returned and failed",
-}
-
-enum FeedbackToGiveStatus {
-  NO_FEEDBACK_TO_GIVE = "No feedback to give",
-  FEEDBACK_TO_GIVE = "Feedback to give",
-}
-
-export enum ReviewsReceivedStatus {
-  NO_REVIEW = "No reviews received",
-  ONE_REVIEW = "1 Review received",
-  TWO_OR_MORE_REVIEWS = "Reviews received",
-}
-
-const enum ReviewsToGiveStatus {
-  NO_REVIEWS_TO_GIVE = "No reviews to give",
-  REVIEWS_TO_GIVE = "Reviews to give",
-}
-
 export type GuideInfo = {
   _id: Types.ObjectId;
   title: string;
@@ -38,23 +15,17 @@ export type GuideInfo = {
   module: ModuleType;
 
   // this user's project returns
-  returnStatus: ReturnStatus;
   returnsSubmitted: ReturnType[];
   feedbackReceived: FeedbackDocument[];
 
   // giving feedback on others' returns
-  feedbackToGiveStatus: FeedbackToGiveStatus; // calculcate this and create typing
   availableForFeedback: ReturnType[];
   feedbackGiven: FeedbackDocument[];
-  feedbackGivenCount: number;
 
   // reviews received by others on feedback given by this user
-  reviewsReceivedStatus: ReviewsReceivedStatus;
   reviewsReceived: ReviewedFeedbackDocument[];
-  reviewsReceivedGrades: number[];
 
   // reviewing others' feedback
-  reviewsToGiveStatus: ReviewsToGiveStatus;
   reviewsGiven: ReviewedFeedbackDocument[];
   availableToReview: ReturnType[];
 };
@@ -270,104 +241,6 @@ export async function getGuides(
     },
   };
 
-  const calculateReturnStatus: PipelineStage = {
-    $addFields: {
-      returnStatus: {
-        $switch: {
-          branches: [
-            {
-              case: { $eq: [{ $size: "$returnsSubmitted" }, 0] },
-              then: ReturnStatus.NOT_RETURNED,
-            },
-            {
-              case: {
-                $and: [
-                  {
-                    $gt: [
-                      { $max: "$feedbackReceived.createdAt" },
-                      { $max: "$returnsSubmitted.createdAt" },
-                    ],
-                  },
-                  {
-                    $eq: ["$feedbackReceived.vote", "no pass"],
-                  },
-                ],
-              },
-              then: ReturnStatus.RETURNED_FAILED,
-            },
-            {
-              case: {
-                $and: [
-                  { $lt: [{ $size: "$reviewsGiven" }, 2] },
-                  {
-                    $gt: [
-                      { $max: "$reviewsGiven.createdAt" },
-                      { $max: "$returnsSubmitted.createdAt" },
-                    ],
-                  },
-                ],
-              },
-              then: ReturnStatus.RETURNED_AWAITING_REVIEW,
-            },
-          ],
-          default: ReturnStatus.RETURNED_FAILED,
-        },
-      },
-    },
-  };
-
-  const calculateFeedbackToGiveStatus: PipelineStage = {
-    $addFields: {
-      feedbackToGiveStatus: {
-        $switch: {
-          branches: [
-            {
-              case: { $gte: [{ $size: "$feedbackGiven" }, 2] },
-              then: FeedbackToGiveStatus.NO_FEEDBACK_TO_GIVE,
-            },
-          ],
-          default: FeedbackToGiveStatus.FEEDBACK_TO_GIVE,
-        },
-      },
-    },
-  };
-
-  const calculateReviewsReceivedStatus: PipelineStage = {
-    $addFields: {
-      reviewsReceivedStatus: {
-        $switch: {
-          branches: [
-            {
-              case: { $eq: [{ $size: "$reviewsReceived" }, 0] },
-              then: ReviewsReceivedStatus.NO_REVIEW,
-            },
-            {
-              case: { $eq: [{ $size: "$reviewsReceived" }, 1] },
-              then: ReviewsReceivedStatus.ONE_REVIEW,
-            },
-          ],
-          default: ReviewsReceivedStatus.TWO_OR_MORE_REVIEWS,
-        },
-      },
-    },
-  };
-
-  const calculateReviewsToGiveStatus: PipelineStage = {
-    $addFields: {
-      reviewsToGiveStatus: {
-        $switch: {
-          branches: [
-            {
-              case: { $lt: [{ $size: "$reviewsGiven" }, 2] },
-              then: ReviewsToGiveStatus.REVIEWS_TO_GIVE,
-            },
-          ],
-          default: ReviewsToGiveStatus.NO_REVIEWS_TO_GIVE,
-        },
-      },
-    },
-  };
-
   // define the final document structure
 
   const defineProject: PipelineStage = {
@@ -380,29 +253,17 @@ export async function getGuides(
       module: 1,
 
       // this user's project returns
-      returnStatus: 1,
       returnsSubmitted: 1,
       feedbackReceived: 1,
 
       // giving feedback on others' returns
-      feedbackToGiveStatus: 1,
       availableForFeedback: 1,
       feedbackGiven: 1,
-      feedbackGivenCount: { $size: "$feedbackGiven" },
 
       // reviews received by others on feedback given by this user
-      reviewsReceivedStatus: 1,
       reviewsReceived: 1,
-      reviewsReceivedGrades: {
-        $map: {
-          input: "$reviewsReceived",
-          as: "review",
-          in: "$$review.grade",
-        },
-      },
 
       // reviewing others' feedback
-      reviewsToGiveStatus: 1,
       reviewsGiven: 1,
       availableToReview: 1,
     },
@@ -410,7 +271,6 @@ export async function getGuides(
 
   try {
     return await Guide.aggregate([
-      // lookup stages
       lookupReturnsSubmitted,
       lookupFeedbackGiven,
       lookupAvailableForFeedback,
@@ -418,12 +278,6 @@ export async function getGuides(
       lookupAvailableToReview,
       lookupFeedbackReceived,
       lookupReviewsReceived,
-
-      // calculations
-      calculateReturnStatus,
-      calculateFeedbackToGiveStatus,
-      calculateReviewsReceivedStatus,
-      calculateReviewsToGiveStatus,
 
       defineProject,
       {

--- a/app/guides/query.tsx
+++ b/app/guides/query.tsx
@@ -3,28 +3,65 @@ import { Guide, ModuleType } from "../models/guide";
 import { ObjectId } from "mongodb";
 import { UserDocument } from "../models/user";
 import { ReturnType } from "../models/return";
-import { ReviewType } from "../models/review";
+import { FeedbackDocument, ReviewedFeedbackDocument } from "../models/review";
 import { PipelineStage, Types } from "mongoose";
 
+enum ReturnStatus {
+  NOT_RETURNED = "Guide not returned",
+  RETURNED_AWAITING_REVIEW = "Guide returned and awaiting review",
+  RETURNED_PASSED = "Guide returned and passed",
+  RETURNED_FAILED = "Guide returned and failed",
+}
+
+enum FeedbackToGiveStatus {
+  NO_FEEDBACK_TO_GIVE = "No feedback to give",
+  FEEDBACK_TO_GIVE = "Feedback to give",
+}
+
+export enum ReviewsReceivedStatus {
+  NO_REVIEW = "No reviews received",
+  ONE_REVIEW = "1 Review received",
+  TWO_OR_MORE_REVIEWS = "Reviews received",
+}
+
+const enum ReviewsToGiveStatus {
+  NO_REVIEWS_TO_GIVE = "No reviews to give",
+  REVIEWS_TO_GIVE = "Reviews to give",
+}
+
 export type GuideInfo = {
-  category: string;
-  description: string;
-  isReturned: boolean;
-  module: ModuleType;
-  oldestReturnId: string;
-  order: number;
-  title: string;
-  returnsSubmitted: ReturnType[];
-  reviewsGiven: ReviewType[];
-  numberOfReviewsGiven: number;
-  reviewsReceived: ReviewType[];
-  returnsToReview: ReturnType[];
   _id: Types.ObjectId;
+  title: string;
+  description: string;
+  category: string;
+  order: number;
+  module: ModuleType;
+
+  // this user's project returns
+  returnStatus: ReturnStatus;
+  returnsSubmitted: ReturnType[];
+  feedbackReceived: FeedbackDocument[];
+
+  // giving feedback on others' returns
+  feedbackToGiveStatus: FeedbackToGiveStatus; // calculcate this and create typing
+  availableForFeedback: ReturnType[];
+  feedbackGiven: FeedbackDocument[];
+  feedbackGivenCount: number;
+
+  // reviews received by others on feedback given by this user
+  reviewsReceivedStatus: ReviewsReceivedStatus;
+  reviewsReceived: ReviewedFeedbackDocument[];
+  reviewsReceivedGrades: number[];
+
+  // reviewing others' feedback
+  reviewsToGiveStatus: ReviewsToGiveStatus;
+  reviewsGiven: ReviewedFeedbackDocument[];
+  availableToReview: ReturnType[];
 };
 
-export interface GuideInfoWithLink extends GuideInfo {
+export type GuideInfoWithLink = GuideInfo & {
   individualGuideLink: string;
-}
+};
 
 export async function getGuides(
   user: UserDocument | null
@@ -34,8 +71,8 @@ export async function getGuides(
 
   const userId = new ObjectId(user._id);
 
-  // grab all returns that the user has made for the guide
-  const lookupUserReturns: PipelineStage = {
+  // grab user's submitted returns
+  const lookupReturnsSubmitted: PipelineStage = {
     $lookup: {
       from: "returns",
       let: { guideId: "$_id" },
@@ -55,8 +92,29 @@ export async function getGuides(
     },
   };
 
-  // grab all returns that the user could review for the guide
-  const lookupReturnsToReview: PipelineStage = {
+  // grab feedback given by user
+  const lookupFeedbackGiven: PipelineStage = {
+    $lookup: {
+      from: "reviews",
+      let: { guideId: "$_id" },
+      pipeline: [
+        {
+          $match: {
+            $expr: {
+              $and: [
+                { $eq: ["$guide", "$$guideId"] },
+                { $eq: ["$owner", userId] },
+              ],
+            },
+          },
+        },
+      ],
+      as: "feedbackGiven",
+    },
+  };
+
+  // grab returns available for reviewing
+  const lookupAvailableForFeedback: PipelineStage = {
     $lookup: {
       from: "returns",
       let: { guideId: "$_id" },
@@ -82,7 +140,7 @@ export async function getGuides(
         {
           $match: {
             "associatedReviews.owner": {
-              $ne: userId, // Assuming userId is defined elsewhere in your script
+              $ne: userId,
             },
           },
         },
@@ -93,11 +151,11 @@ export async function getGuides(
           },
         },
       ],
-      as: "returnsToReview",
+      as: "availableForFeedback",
     },
   };
 
-  // grab all reviews made by the user for each guide
+  // grab reviews given by user
   const lookupReviewsGiven: PipelineStage = {
     $lookup: {
       from: "reviews",
@@ -108,7 +166,7 @@ export async function getGuides(
             $expr: {
               $and: [
                 { $eq: ["$guide", "$$guideId"] },
-                { $eq: ["$owner", userId] },
+                { $eq: ["$reviewer", userId] },
               ],
             },
           },
@@ -118,8 +176,30 @@ export async function getGuides(
     },
   };
 
-  // grab reviews made by other users for the return that the user has made
-  const lookupReviewsReceived: PipelineStage = {
+  // grab feedback available for reviewing by user
+  const lookupAvailableToReview: PipelineStage = {
+    $lookup: {
+      from: "reviews",
+      let: { guideId: "$_id" },
+      pipeline: [
+        {
+          $match: {
+            $expr: {
+              $and: [
+                { $eq: ["$guide", "$$guideId"] },
+                { $ne: ["$owner", userId] },
+                { $ne: ["$reviewer", userId] },
+              ],
+            },
+          },
+        },
+      ],
+      as: "availableToReview",
+    },
+  };
+
+  // grab feedbackReceived from others
+  const lookupFeedbackReceived: PipelineStage = {
     $lookup: {
       from: "reviews",
       let: { guideId: "$_id" },
@@ -150,36 +230,201 @@ export async function getGuides(
           },
         },
       ],
+      as: "feedbackReceived",
+    },
+  };
+
+  // grab reviews received from others
+  const lookupReviewsReceived: PipelineStage = {
+    $lookup: {
+      from: "reviews",
+      let: { guideId: "$_id" },
+      pipeline: [
+        // First, perform a lookup on the Return collection
+        {
+          $lookup: {
+            from: "returns",
+            localField: "return",
+            foreignField: "_id",
+            as: "returnData",
+          },
+        },
+        // Unwind the array, so we can easily access the owner field
+        {
+          $unwind: "$returnData",
+        },
+        // Filter by guide and owner
+        {
+          $match: {
+            $expr: {
+              $and: [
+                { $eq: ["$guide", "$$guideId"] },
+                { $eq: ["$owner", userId] },
+                { $ne: ["$reviewer", userId] },
+              ],
+            },
+          },
+        },
+      ],
       as: "reviewsReceived",
     },
   };
 
+  const calculateReturnStatus: PipelineStage = {
+    $addFields: {
+      returnStatus: {
+        $switch: {
+          branches: [
+            {
+              case: { $eq: [{ $size: "$returnsSubmitted" }, 0] },
+              then: ReturnStatus.NOT_RETURNED,
+            },
+            {
+              case: {
+                $and: [
+                  {
+                    $gt: [
+                      { $max: "$feedbackReceived.createdAt" },
+                      { $max: "$returnsSubmitted.createdAt" },
+                    ],
+                  },
+                  {
+                    $eq: ["$feedbackReceived.vote", "no pass"],
+                  },
+                ],
+              },
+              then: ReturnStatus.RETURNED_FAILED,
+            },
+            {
+              case: {
+                $and: [
+                  { $lt: [{ $size: "$reviewsGiven" }, 2] },
+                  {
+                    $gt: [
+                      { $max: "$reviewsGiven.createdAt" },
+                      { $max: "$returnsSubmitted.createdAt" },
+                    ],
+                  },
+                ],
+              },
+              then: ReturnStatus.RETURNED_AWAITING_REVIEW,
+            },
+          ],
+          default: ReturnStatus.RETURNED_FAILED,
+        },
+      },
+    },
+  };
+
+  const calculateFeedbackToGiveStatus: PipelineStage = {
+    $addFields: {
+      feedbackToGiveStatus: {
+        $switch: {
+          branches: [
+            {
+              case: { $gte: [{ $size: "$feedbackGiven" }, 2] },
+              then: FeedbackToGiveStatus.NO_FEEDBACK_TO_GIVE,
+            },
+          ],
+          default: FeedbackToGiveStatus.FEEDBACK_TO_GIVE,
+        },
+      },
+    },
+  };
+
+  const calculateReviewsReceivedStatus: PipelineStage = {
+    $addFields: {
+      reviewsReceivedStatus: {
+        $switch: {
+          branches: [
+            {
+              case: { $eq: [{ $size: "$reviewsReceived" }, 0] },
+              then: ReviewsReceivedStatus.NO_REVIEW,
+            },
+            {
+              case: { $eq: [{ $size: "$reviewsReceived" }, 1] },
+              then: ReviewsReceivedStatus.ONE_REVIEW,
+            },
+          ],
+          default: ReviewsReceivedStatus.TWO_OR_MORE_REVIEWS,
+        },
+      },
+    },
+  };
+
+  const calculateReviewsToGiveStatus: PipelineStage = {
+    $addFields: {
+      reviewsToGiveStatus: {
+        $switch: {
+          branches: [
+            {
+              case: { $lt: [{ $size: "$reviewsGiven" }, 2] },
+              then: ReviewsToGiveStatus.REVIEWS_TO_GIVE,
+            },
+          ],
+          default: ReviewsToGiveStatus.NO_REVIEWS_TO_GIVE,
+        },
+      },
+    },
+  };
+
   // define the final document structure
+
   const defineProject: PipelineStage = {
     $project: {
+      _id: 1,
       title: 1,
       description: 1,
-      _id: 1,
-      module: 1,
-      returnsSubmitted: 1,
-      returnDate: { $arrayElemAt: ["$returnsSubmitted.createdAt", 0] },
-      // oldestReturnId: { $arrayElemAt: ["$returnsToReview._id", 0] },
-      returnsToReview: 1,
-      isReturned: { $gt: [{ $size: "$returnsSubmitted" }, 0] },
-      numberOfReviewsGiven: { $size: "$reviewsGiven" },
-      reviewsReceived: 1,
-      reviewsGiven: 1,
       category: 1,
       order: 1,
+      module: 1,
+
+      // this user's project returns
+      returnStatus: 1,
+      returnsSubmitted: 1,
+      feedbackReceived: 1,
+
+      // giving feedback on others' returns
+      feedbackToGiveStatus: 1,
+      availableForFeedback: 1,
+      feedbackGiven: 1,
+      feedbackGivenCount: { $size: "$feedbackGiven" },
+
+      // reviews received by others on feedback given by this user
+      reviewsReceivedStatus: 1,
+      reviewsReceived: 1,
+      reviewsReceivedGrades: {
+        $map: {
+          input: "$reviewsReceived",
+          as: "review",
+          in: "$$review.grade",
+        },
+      },
+
+      // reviewing others' feedback
+      reviewsToGiveStatus: 1,
+      reviewsGiven: 1,
+      availableToReview: 1,
     },
   };
 
   try {
     return await Guide.aggregate([
-      lookupUserReturns,
-      lookupReturnsToReview,
+      // lookup stages
+      lookupReturnsSubmitted,
+      lookupFeedbackGiven,
+      lookupAvailableForFeedback,
       lookupReviewsGiven,
+      lookupAvailableToReview,
+      lookupFeedbackReceived,
       lookupReviewsReceived,
+
+      // calculations
+      calculateReturnStatus,
+      calculateFeedbackToGiveStatus,
+      calculateReviewsReceivedStatus,
+      calculateReviewsToGiveStatus,
+
       defineProject,
       {
         $sort: {

--- a/app/guides/types.ts
+++ b/app/guides/types.ts
@@ -1,0 +1,65 @@
+import { Types } from "mongoose";
+import { ModuleType } from "../models/guide";
+import {
+  FeedbackDocument,
+  Review,
+  ReviewedFeedbackDocument,
+} from "../models/review";
+import { ReturnDocument, ReturnType } from "../models/return";
+
+export type GuideInfo = {
+  _id: Types.ObjectId;
+  title: string;
+  description: string;
+  category: string;
+  order: number;
+  module: ModuleType;
+
+  // this user's project returns
+  returnsSubmitted: ReturnDocument[];
+  feedbackReceived: FeedbackDocument[];
+
+  // giving feedback on others' returns
+  availableForFeedback: ReturnDocument[];
+  feedbackGiven: FeedbackDocument[];
+
+  // reviews received by others on feedback given by this user
+  reviewsReceived: ReviewedFeedbackDocument[];
+
+  // reviewing others' feedback
+  reviewsGiven: ReviewedFeedbackDocument[];
+  availableToReview: ReturnType[];
+};
+
+export type Module = {
+  title: string;
+  number: number;
+};
+
+export type GuideInfoWithLink = GuideInfo & {
+  individualGuideLink: string;
+};
+
+export enum ReturnStatus {
+  NOT_RETURNED = "Not Returned",
+  AWAITING_FEEDBACK = "Awaiting feedback",
+  PASSED = "Passed",
+  FAILED = "Failed",
+}
+
+export enum FeedbackStatus {
+  AWAITING_PROJECTS = "Awaiting projects to review",
+  NEED_TO_PROVIDE_FEEDBACK = "Need to provide feedback",
+  FEEDBACK_GIVEN = "Feedback given",
+}
+
+export enum ReviewsReceivedStatus {
+  AWAITING_REVIEWS = "Awaiting reviews from others",
+  REVIEWS_RECEIVED = "Reviews received",
+}
+
+export enum ReviewsGivenStatus {
+  AWAITING_FEEDBACK = "Awaiting feedback to review",
+  NEED_TO_REVIEW = "Need to review",
+  REVIEWS_GIVEN = "Reviews given",
+}

--- a/app/guides/utils.ts
+++ b/app/guides/utils.ts
@@ -1,0 +1,96 @@
+"use server";
+import { ReturnDocument } from "../models/return";
+import {
+  FeedbackDocument,
+  ReviewedFeedbackDocument,
+  Vote,
+} from "../models/review";
+import {
+  ReturnStatus,
+  FeedbackStatus,
+  ReviewsReceivedStatus,
+  ReviewsGivenStatus,
+} from "./types";
+
+export const calculateReturnStatus = (
+  returnedGuides: ReturnDocument[],
+  feedbackReceived: FeedbackDocument[]
+): ReturnStatus => {
+  if (returnedGuides.length === 0) {
+    return ReturnStatus.NOT_RETURNED;
+  }
+
+  const latestSubmission = returnedGuides.reduce(
+    (latestSubmission, submission) => {
+      if (submission.createdAt > latestSubmission.createdAt) {
+        return submission;
+      }
+      return latestSubmission;
+    }
+  );
+  const feedbackOnLatestSubmission = feedbackReceived.filter((feedback) => {
+    return feedback.return === latestSubmission._id;
+  });
+
+  if (
+    feedbackOnLatestSubmission.filter(
+      (feedback) => feedback.vote === Vote.NO_PASS
+    ).length > 0
+  ) {
+    return ReturnStatus.FAILED;
+  }
+  if (feedbackOnLatestSubmission.length < 2) {
+    return ReturnStatus.AWAITING_FEEDBACK;
+  }
+
+  return ReturnStatus.PASSED;
+};
+
+export const calculateFeedbackStatus = (
+  feedbackGiven: FeedbackDocument[],
+  availableForFeedback: ReturnDocument[]
+): FeedbackStatus => {
+  if (feedbackGiven.length < 2 && availableForFeedback.length === 0) {
+    return FeedbackStatus.AWAITING_PROJECTS;
+  }
+  if (feedbackGiven.length < 2) {
+    return FeedbackStatus.NEED_TO_PROVIDE_FEEDBACK;
+  }
+  return FeedbackStatus.FEEDBACK_GIVEN;
+};
+
+export const calculateReviewsReceivedStatus = (
+  reviewsReceived: ReviewedFeedbackDocument[]
+): ReviewsReceivedStatus => {
+  if (reviewsReceived.length < 2) {
+    return ReviewsReceivedStatus.AWAITING_REVIEWS;
+  }
+  return ReviewsReceivedStatus.REVIEWS_RECEIVED;
+};
+
+export const calculateReviewScore = (
+  reviewsReceived: ReviewedFeedbackDocument[]
+): number | undefined => {
+  if (reviewsReceived.length < 2) {
+    return undefined;
+  }
+  const highestTwoReviews = reviewsReceived
+    .sort((a, b) => b.grade - a.grade)
+    .slice(0, 2);
+
+  return (highestTwoReviews[0].grade + highestTwoReviews[1].grade) / 2;
+};
+
+export const calculateReviewGivenStatus = (
+  reviewsGiven: ReviewedFeedbackDocument[],
+  availableToReview: ReturnDocument[]
+): ReviewsGivenStatus => {
+  if (reviewsGiven.length >= 2) {
+    return ReviewsGivenStatus.REVIEWS_GIVEN;
+  }
+  if (availableToReview.length > 0) {
+    return ReviewsGivenStatus.NEED_TO_REVIEW;
+  }
+
+  return ReviewsGivenStatus.AWAITING_FEEDBACK;
+};

--- a/app/models/guide.ts
+++ b/app/models/guide.ts
@@ -64,5 +64,5 @@ export type GuideType = InferSchemaType<typeof guideSchema> & {
 
 export type ModuleType = InferSchemaType<typeof guideModuleSchema>;
 
-type GuideDocument = GuideType & Document;
+export type GuideDocument = GuideType & Document;
 export const Guide = models.Guide || model<GuideDocument>("Guide", guideSchema);

--- a/app/models/return.ts
+++ b/app/models/return.ts
@@ -23,6 +23,6 @@ export type ReturnType = InferSchemaType<typeof returnSchema> & {
   _id: Types.ObjectId;
 };
 
-type ReturnDocument = ReturnType & Document;
+export type ReturnDocument = ReturnType & Document;
 export const Return =
   models.Return || model<ReturnDocument>("Return", returnSchema);

--- a/app/models/review.ts
+++ b/app/models/review.ts
@@ -10,23 +10,40 @@ import {
 const reviewSchema = new Schema({
   guide: { type: Schema.Types.ObjectId, required: false, ref: "Guide" },
   return: { type: Schema.Types.ObjectId, required: true, ref: "Return" },
+
+  // the owner is the user who submitted the feedback and gave a vote and comment
   owner: { type: Schema.Types.ObjectId, required: true, ref: "User" },
-  comment: { type: Schema.Types.String, required: true },
   vote: {
     type: Schema.Types.String,
     required: true,
     enum: ["no pass", "pass", "recommend to gallery"],
   },
+  comment: { type: Schema.Types.String, required: true },
+
   createdAt: { type: Schema.Types.Date, required: true, default: Date.now },
   updatedAt: { type: Schema.Types.Date, required: false },
   commentAnswer: { type: Schema.Types.String, required: false },
+
+  // the reviewer is the user who reviewed the feedback and gave a grade
+  reviewer: { type: Schema.Types.ObjectId, required: false, ref: "User" },
   grade: { type: Schema.Types.Number, required: false },
 });
 
-export type ReviewType = InferSchemaType<typeof reviewSchema> & {
+export type FeedbackType = InferSchemaType<typeof reviewSchema> & {
   _id: Types.ObjectId;
 };
 
-type ReviewDocument = ReviewType & Document;
+// after someone has reviewed the feedback it becomes a reviewed feedback
+export type ReviewedFeedbackType = FeedbackType & {
+  reviewer: Types.ObjectId;
+  grade: number;
+};
+
+export type FeedbackDocument = FeedbackType & Document;
+
+export type ReviewedFeedbackDocument = FeedbackDocument & {
+  reviewer: Types.ObjectId;
+  grade: number;
+};
 export const Review =
-  models.Review || model<ReviewDocument>("Review", reviewSchema);
+  models.Review || model<FeedbackDocument>("Review", reviewSchema);

--- a/app/models/review.ts
+++ b/app/models/review.ts
@@ -7,6 +7,12 @@ import {
   Types,
 } from "mongoose";
 
+export enum Vote {
+  NO_PASS = "no pass",
+  PASS = "pass",
+  RECOMMEND_TO_GALLERY = "recommend to gallery",
+}
+
 const reviewSchema = new Schema({
   guide: { type: Schema.Types.ObjectId, required: false, ref: "Guide" },
   return: { type: Schema.Types.ObjectId, required: true, ref: "Return" },
@@ -16,7 +22,7 @@ const reviewSchema = new Schema({
   vote: {
     type: Schema.Types.String,
     required: true,
-    enum: ["no pass", "pass", "recommend to gallery"],
+    enum: Object.values(Vote),
   },
   comment: { type: Schema.Types.String, required: true },
 

--- a/app/utils/actions.ts
+++ b/app/utils/actions.ts
@@ -10,7 +10,6 @@ import { FilterQuery, Types } from "mongoose";
 import { GuideType } from "../models/guide";
 import { connectToDatabase } from "./mongoose-connector";
 import { Guide } from "../models/guide";
-import { Module } from "./types";
 
 export const signOut = s; //needs to be in actions.ts so that it can be called on the client side
 export async function authenticate(

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1,4 +1,0 @@
-export type Module = {
-  title: string;
-  number: number;
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   moduleNameMapper: {
     "^components/(.*)$": "<rootDir>/app/components/$1",
   },
-  testPathIgnorePatterns: ["<rootDir>/__tests__/mongoQueries/mongoHandler.ts"],
+  testPathIgnorePatterns: ["<rootDir>/__tests__/__mocks__/mongoHandler.ts"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
- add additional typing
- test status calculations 
- improve naming


All relevant subsets of returns, reviews etc will be returned for every guide with getGuides.
Simple calculations can then be called to get statuses, which will be used by the front-end to inform the user 