### PR TITLE
controll ReturnForm with useSessionState

### DIFF
--- a/__tests__/serverActions/returnGuide.test.ts
+++ b/__tests__/serverActions/returnGuide.test.ts
@@ -1,11 +1,11 @@
-import { auth } from "../../auth";
+import { auth } from "auth";
 import { Return } from "models/return";
 import {
   closeDatabase,
   clearDatabase,
   connect,
 } from "../__mocks__/mongoHandler";
-import { Types } from "mongoose";
+import { ObjectId } from "mongodb";
 import { returnGuide } from "serverActions/returnGuide";
 
 jest.mock("../../auth", () => ({
@@ -19,49 +19,64 @@ describe("returnGuide", () => {
     await clearDatabase();
     jest.clearAllMocks();
   });
-  const projectUrl = "https://github.com/example/project";
-  const liveVersion = "https://example.com/live-version";
-  const projectName = "Example Project";
-  const comment = "This is an example project.";
-  const guideId = new Types.ObjectId();
-  const returnUserId = new Types.ObjectId();
-  (auth as jest.Mock).mockResolvedValueOnce({
-    user: { id: returnUserId },
-  });
+
   it("should return a guide", async () => {
-    const state = {}; // Add any necessary properties to this object
-    const formData = new FormData();
-    formData.append("projectUrl", projectUrl);
-    formData.append("liveVersion", liveVersion);
-    formData.append("projectName", projectName);
-    formData.append("comment", comment);
-    formData.append("imageOfProject", "");
-    formData.append("guideId", guideId.toString());
+    const projectUrl = "https://github.com/example/project";
+    const liveVersion = "https://example.com/live-version";
+    const projectName = "Example Project";
+    const comment = "This is an example project.";
+    const guideId = new ObjectId().toString();
+    const returnUserId = new ObjectId().toString();
+
+    (auth as jest.Mock).mockResolvedValueOnce({
+      user: { id: returnUserId },
+    });
+
+    const state = {};
+    const formData = {
+      projectUrl,
+      liveVersion,
+      projectName,
+      comment,
+      guideId,
+    };
     const result = await returnGuide(state, formData);
     expect(result).toEqual({
       success: true,
       message: "Return submitted successfully",
     });
     const theReturn = await Return.findOne({ owner: returnUserId });
-    expect(theReturn).toMatchObject({
+
+    const actualReturn = theReturn.toObject();
+    const expectedReturn = expect.objectContaining({
       projectUrl,
       liveVersion,
       projectName,
       comment,
-      owner: returnUserId,
-      guide: guideId,
+      owner: new ObjectId(returnUserId),
+      guide: new ObjectId(guideId),
     });
+
+    expect(actualReturn).toMatchObject(expectedReturn);
   });
   it("should handle form parsing errors", async () => {
     const state = {};
-    const formData = new FormData();
-    formData.append("projectUrl", ""); // Empty string should fail validation
-    formData.append("liveVersion", ""); // Empty string should fail validation
-    formData.append("projectName", ""); // Empty string should fail validation
-    formData.append("comment", ""); // Empty string should fail validation
-    formData.append("guideId", guideId.toString());
+    const formData = {
+      projectUrl: "",
+      liveVersion: "",
+      projectName: "",
+      comment: "",
+      guideId: "",
+    };
     const result = await returnGuide(state, formData);
-    expect(result.success).toBe(false);
-    expect(result.errors).toBeDefined();
+    expect(result).toEqual({
+      errors: {
+        projectUrl: [expect.any(String)],
+        liveVersion: [expect.any(String)],
+        projectName: [expect.any(String)],
+        comment: [expect.any(String)],
+      },
+      success: false,
+    });
   });
 });

--- a/app/UIcomponents/input/Input.tsx
+++ b/app/UIcomponents/input/Input.tsx
@@ -1,6 +1,7 @@
 "use client";
 import styled from "styled-components";
 import { Wrapper, Label, ReusableInput, ReusableTextarea } from "./style";
+import { SmallText } from "globalStyles/text";
 
 type InputProps = {
   label: string;
@@ -12,18 +13,28 @@ type InputProps = {
 export const Input = ({ label, id, error, ...props }: InputProps) => {
   return (
     <Wrapper>
-      <Label htmlFor={id}>{label}</Label>
-      {props.type === "textarea" ? (
-        <ReusableTextarea id={id} {...props} />
-      ) : (
-        <ReusableInput id={id} {...props} />
-      )}
-      <ErrorMessage>{error}</ErrorMessage>
+      <Label>
+        {label}
+        {props.type === "textarea" ? (
+          <ReusableTextarea
+            id={id}
+            aria-describedby={error ? `${id}-error` : undefined}
+            {...props}
+          />
+        ) : (
+          <ReusableInput
+            id={id}
+            aria-describedby={error ? `${id}-error` : undefined}
+            {...props}
+          />
+        )}
+      </Label>
+      {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
     </Wrapper>
   );
 };
 
-export const ErrorMessage = styled.p`
+export const ErrorMessage = styled(SmallText)`
   color: var(--error-failure-100);
   font-size: 14px;
 `;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,9 +27,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  console.log("before auth");
   const session = await auth();
-  console.log("after auth");
 
   return (
     <html lang="en">

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -27,6 +27,7 @@ const config: Config = {
     "^types/(.*)$": "<rootDir>/types/$1",
   },
   testPathIgnorePatterns: ["<rootDir>/__tests__/__mocks__/mongoHandler.ts"],
+  transformIgnorePatterns: ["/node_modules/(?!(react-session-hooks)/)"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
- The test for returnForm fails because the npm package for react-session-hooks only uses ESM. I will be updating the library to also return commonJS so Jest should then be happy with it. 
- - Tested when it was just useState and all tests passed, and tried manually