### PR TITLE
refactor: split guide category into orthogonal axes + auto-graded slide

### DIFF
--- a/__tests__/utils/guideTaxonomy.test.ts
+++ b/__tests__/utils/guideTaxonomy.test.ts
@@ -1,0 +1,62 @@
+import {
+  categoryToAxes,
+  axesToCategory,
+  getDiscipline,
+  getIsSpecialty,
+  isCodeCategory,
+} from "utils/guideTaxonomy";
+
+describe("categoryToAxes", () => {
+  it("maps every legacy category to the right axes", () => {
+    expect(categoryToAxes("code")).toEqual({ discipline: "code", isSpecialty: false });
+    expect(categoryToAxes("design")).toEqual({ discipline: "design", isSpecialty: false });
+    expect(categoryToAxes("codeSpeciality")).toEqual({ discipline: "code", isSpecialty: true });
+    expect(categoryToAxes("designSpeciality")).toEqual({ discipline: "design", isSpecialty: true });
+  });
+
+  it("falls back to code/non-specialty for unknown or empty values", () => {
+    expect(categoryToAxes(undefined)).toEqual({ discipline: "code", isSpecialty: false });
+    expect(categoryToAxes("")).toEqual({ discipline: "code", isSpecialty: false });
+    expect(categoryToAxes("nonsense")).toEqual({ discipline: "code", isSpecialty: false });
+  });
+});
+
+describe("axesToCategory", () => {
+  it("round-trips with categoryToAxes for all four combinations", () => {
+    for (const category of ["code", "design", "codeSpeciality", "designSpeciality"]) {
+      const axes = categoryToAxes(category);
+      expect(axesToCategory(axes.discipline, axes.isSpecialty)).toBe(category);
+    }
+  });
+});
+
+describe("getDiscipline / getIsSpecialty", () => {
+  it("prefers the canonical fields when present", () => {
+    const guide = { discipline: "design", isSpecialty: true, category: "code" };
+    expect(getDiscipline(guide)).toBe("design");
+    expect(getIsSpecialty(guide)).toBe(true);
+  });
+
+  it("falls back to deriving from category when the fields are absent", () => {
+    const guide = { category: "designSpeciality" };
+    expect(getDiscipline(guide)).toBe("design");
+    expect(getIsSpecialty(guide)).toBe(true);
+  });
+
+  it("treats an invalid discipline field as absent and derives instead", () => {
+    const guide = { discipline: "garbage", category: "design" };
+    expect(getDiscipline(guide)).toBe("design");
+  });
+});
+
+describe("isCodeCategory (regression for the 'speciality code' bug)", () => {
+  it("treats both code and codeSpeciality as code", () => {
+    expect(isCodeCategory("code")).toBe(true);
+    expect(isCodeCategory("codeSpeciality")).toBe(true);
+  });
+
+  it("treats design and designSpeciality as not code", () => {
+    expect(isCodeCategory("design")).toBe(false);
+    expect(isCodeCategory("designSpeciality")).toBe(false);
+  });
+});

--- a/app/LMS/components/feedback/giveFeedbackView/GiveFeedbackView.tsx
+++ b/app/LMS/components/feedback/giveFeedbackView/GiveFeedbackView.tsx
@@ -7,6 +7,7 @@ import {
   WriteFeedbackContainer,
 } from "../../../../guides/components/guideCard/style";
 import { SubHeading1 } from "globalStyles/text";
+import { isCodeCategory } from "utils/guideTaxonomy";
 import RichTextEditor from "UIcomponents/markdown/RichTextEditor";
 import {
   useActionState,
@@ -136,7 +137,7 @@ export const GiveFeedbackView = ({ guideTitle }: { guideTitle: string }) => {
             type="button"
             $styletype="outlined"
             onClick={() => {
-              const isCodeGuide = guide.category === 'code' || guide.category === 'speciality code';
+              const isCodeGuide = isCodeCategory(guide.category);
               const tips = isCodeGuide
                 ? "Code Review Focus Areas:\n• Code readability and structure\n• Problem-solving approach\n• Best practices implementation\n• Edge case handling\n• Performance considerations"
                 : "Design Review Focus Areas:\n• Visual hierarchy and layout\n• Color and typography choices\n• User experience flow\n• Responsive design\n• Accessibility considerations";

--- a/app/LMS/docs/GradingSlideshow.tsx
+++ b/app/LMS/docs/GradingSlideshow.tsx
@@ -352,6 +352,29 @@ const slides: SlideDef[] = [
     ),
   },
   {
+    icon: "⚡",
+    title: "Some guides grade themselves",
+    body: (
+      <SlideBody>
+        <p>
+          A few guides aren&apos;t peer-reviewed projects at all — they&apos;re{" "}
+          <strong>interactive exercises</strong> (like quizzes) that are{" "}
+          <strong>graded instantly</strong>.
+        </p>
+        <p>
+          There&apos;s no return and no reviews: you answer the exercise, it&apos;s
+          checked automatically, and your score (out of 10) becomes your grade for
+          that guide. You can <strong>try again</strong> to improve it — your best
+          attempt counts.
+        </p>
+        <Callout>
+          These count toward your progress just like any other guide — they&apos;re
+          just faster, with instant feedback.
+        </Callout>
+      </SlideBody>
+    ),
+  },
+  {
     icon: "🚀",
     title: "Specialty guides & quick tips",
     body: (

--- a/app/UIcomponents/markdown/RichTextEditor.tsx
+++ b/app/UIcomponents/markdown/RichTextEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from "react";
 import styled from "styled-components";
+import { isCodeCategory } from "utils/guideTaxonomy";
 
 const EditorContainer = styled.div`
   border: 1px solid #ccc;
@@ -298,7 +299,10 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
     executeCommand('insertOrderedList');
   }, [executeCommand]);
 
-  const isCodeGuide = guideCategory === 'code' || guideCategory === 'speciality code';
+  // Route through the taxonomy helper so specialty-code guides (codeSpeciality)
+  // are correctly treated as code — the old `=== 'speciality code'` check never
+  // matched and silently showed design tips on specialty-code guides.
+  const isCodeGuide = isCodeCategory(guideCategory);
 
   const codeReviewTips = [
     "Check if the code is clean and readable",

--- a/app/api/guides/route.ts
+++ b/app/api/guides/route.ts
@@ -33,7 +33,9 @@ export async function POST() {
     const draft = await Guide.create({
       title: "Untitled guide",
       description: "TODO: add a description",
-      category: "code",
+      discipline: "code",
+      isSpecialty: false,
+      category: "code", // derived mirror of (discipline, isSpecialty)
       topicsList: "TODO",
       order: nextOrder,
       themeIdea: { title: "Project", description: "TODO: add the task" },

--- a/app/components/editGuides/EditGuideForm.tsx
+++ b/app/components/editGuides/EditGuideForm.tsx
@@ -3,8 +3,13 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
 import { GuideType } from "../../models/guide";
-import { GUIDE_CATEGORIES } from "../../constants/guideCategories";
 import { MODULE_TITLES } from "../../constants/moduleTitles";
+import {
+  getDiscipline,
+  getIsSpecialty,
+  axesToCategory,
+  type Discipline,
+} from "../../utils/guideTaxonomy";
 import {
   ExerciseEditor,
   emptyTask,
@@ -71,10 +76,13 @@ export const EditGuideForm = ({ guide }: EditGuideFormProps) => {
     return { passThreshold: 0.7, tasks: [emptyTask()] };
   });
 
+  // Canonical taxonomy axes (category is derived from these on save).
+  const [discipline, setDiscipline] = useState<Discipline>(getDiscipline(guide));
+  const [isSpecialty, setIsSpecialty] = useState<boolean>(getIsSpecialty(guide));
+
   const [formData, setFormData] = useState({
     title: guide.title || '',
     description: guide.description || '',
-    category: guide.category || '',
     topicsList: guide.topicsList || '',
     order: guide.order || 0,
     themeIdea: {
@@ -200,6 +208,10 @@ export const EditGuideForm = ({ guide }: EditGuideFormProps) => {
         body: JSON.stringify({
           ...formData,
           ...gradingPayload,
+          // Canonical taxonomy axes + derived legacy `category` mirror.
+          discipline,
+          isSpecialty,
+          category: axesToCategory(discipline, isSpecialty),
           knowledge: formData.knowledge.map(k => ({ knowledge: k })),
           skills: formData.skills.map(s => ({ skill: s })),
           updatedAt: new Date().toISOString()
@@ -255,20 +267,30 @@ export const EditGuideForm = ({ guide }: EditGuideFormProps) => {
           </InputGroup>
 
           <InputGroup>
-            <Label htmlFor="category">Category</Label>
+            <Label htmlFor="discipline">Discipline</Label>
             <Select
-              id="category"
-              value={formData.category}
-              onChange={(e) => handleInputChange('category', e.target.value)}
+              id="discipline"
+              value={discipline}
+              onChange={(e) => setDiscipline(e.target.value as Discipline)}
               required
             >
-              <option value="">Select a category</option>
-              {GUIDE_CATEGORIES.map(category => (
-                <option key={category} value={category}>
-                  {category}
-                </option>
-              ))}
+              <option value="code">Code</option>
+              <option value="design">Design</option>
             </Select>
+          </InputGroup>
+
+          <InputGroup>
+            <Label htmlFor="isSpecialty">
+              <input
+                id="isSpecialty"
+                type="checkbox"
+                checked={isSpecialty}
+                onChange={(e) => setIsSpecialty(e.target.checked)}
+                style={{ marginRight: "0.5rem" }}
+              />
+              Specialty guide (optional — can replace a lower grade in the same
+              discipline, and does not count toward progress)
+            </Label>
           </InputGroup>
 
           <InputGroup>

--- a/app/components/studentHome/StudentHomePage.tsx
+++ b/app/components/studentHome/StudentHomePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExtendedGuideInfo, Module, ReviewStatus, ReturnStatus } from "types/guideTypes";
+import { getDiscipline, getIsSpecialty } from "utils/guideTaxonomy";
 import GuideCard from "../../guides/components/guideCard/GuideCard";
 import {
   HomeContainer,
@@ -72,9 +73,9 @@ export const StudentHomePage = ({ extendedGuides, modules }: StudentHomePageProp
     };
   }, [extendedGuides]);
 
-  // Helper to check if a guide is a specialty guide
-  const isSpecialtyGuide = (guide: ExtendedGuideInfo) =>
-    guide.category === 'codeSpeciality' || guide.category === 'designSpeciality';
+  // Helper to check if a guide is a specialty guide (reads the canonical axis,
+  // falling back to deriving from the legacy category — see utils/guideTaxonomy).
+  const isSpecialtyGuide = (guide: ExtendedGuideInfo) => getIsSpecialty(guide);
 
   // Calculate progress for each module (exclude modules 0, 2 and specialty guides)
   const moduleProgress = useMemo(() => {
@@ -124,11 +125,13 @@ export const StudentHomePage = ({ extendedGuides, modules }: StudentHomePageProp
           extractModuleNumber(guide.module.title) === module.number
         );
         
-        // Separate regular and specialty guides
-        const regularCodingGuides = moduleGuides.filter(guide => guide.category === 'code');
-        const specialtyCodingGuides = moduleGuides.filter(guide => guide.category === 'codeSpeciality');
-        const regularDesignGuides = moduleGuides.filter(guide => guide.category === 'design');
-        const specialtyDesignGuides = moduleGuides.filter(guide => guide.category === 'designSpeciality');
+        // Separate regular and specialty guides by discipline.
+        const isCoding = (g: ExtendedGuideInfo) => getDiscipline(g) === 'code';
+        const isDesign = (g: ExtendedGuideInfo) => getDiscipline(g) === 'design';
+        const regularCodingGuides = moduleGuides.filter(g => isCoding(g) && !getIsSpecialty(g));
+        const specialtyCodingGuides = moduleGuides.filter(g => isCoding(g) && getIsSpecialty(g));
+        const regularDesignGuides = moduleGuides.filter(g => isDesign(g) && !getIsSpecialty(g));
+        const specialtyDesignGuides = moduleGuides.filter(g => isDesign(g) && getIsSpecialty(g));
         
         // Calculate final coding grades with specialty logic
         const finalCodingGrades = calculateFinalGrades(regularCodingGuides, specialtyCodingGuides);

--- a/app/models/guide.ts
+++ b/app/models/guide.ts
@@ -74,6 +74,18 @@ const exerciseSchema = new Schema({
 });
 
 const guideSchema = new Schema({
+  // Canonical taxonomy axes (see app/utils/guideTaxonomy.ts). Not strictly
+  // required so existing/un-migrated docs still read fine — the taxonomy helpers
+  // fall back to deriving these from `category`.
+  discipline: {
+    type: Schema.Types.String,
+    enum: ["code", "design"],
+    required: false,
+  },
+  isSpecialty: { type: Schema.Types.Boolean, required: false, default: false },
+  // DERIVED mirror of (discipline, isSpecialty), kept for legacy/display/LTI
+  // consumers. Written on every save via axesToCategory; never string-matched
+  // directly in logic.
   category: { type: Schema.Types.String, required: true },
   references: { type: [guideReferenceSchema], required: true },
   title: { type: Schema.Types.String, required: true },

--- a/app/serverActions/getGuides.ts
+++ b/app/serverActions/getGuides.ts
@@ -299,6 +299,8 @@ const getGuidesPipelines = (userId: ObjectId): PipelineStage[] => {
       title: 1,
       description: 1,
       category: 1,
+      discipline: 1,
+      isSpecialty: 1,
       order: 1,
       module: 1,
       gradingMode: 1,

--- a/app/serverActions/getPublicGuides.ts
+++ b/app/serverActions/getPublicGuides.ts
@@ -16,6 +16,8 @@ export async function getPublicGuides(): Promise<GuideType[] | null> {
         title: 1,
         description: 1,
         category: 1,
+        discipline: 1,
+        isSpecialty: 1,
         order: 1,
         module: 1,
         references: 1,

--- a/app/utils/guideTaxonomy.ts
+++ b/app/utils/guideTaxonomy.ts
@@ -1,0 +1,81 @@
+/**
+ * Guide taxonomy: two orthogonal axes.
+ *
+ *   discipline:  "code" | "design"
+ *   isSpecialty: boolean   (specialty guides are optional/extra)
+ *
+ * Historically these were mashed into a single `category` enum
+ * ("code" | "design" | "codeSpeciality" | "designSpeciality"), which invited a
+ * combinatorial blow-up (every new axis multiplies the values) and string-match
+ * bugs (e.g. checking `category === 'speciality code'`, which never matched the
+ * real value `codeSpeciality`).
+ *
+ * `discipline` + `isSpecialty` are now the canonical fields. `category` is kept
+ * on the document as a DERIVED mirror (written on save) so legacy/display/LTI
+ * consumers keep working. Always read the axes through the helpers below — never
+ * string-match `category` ad hoc again.
+ */
+
+export type Discipline = "code" | "design";
+
+export const DISCIPLINES: readonly Discipline[] = ["code", "design"] as const;
+
+export type GuideAxes = { discipline: Discipline; isSpecialty: boolean };
+
+/** Anything we can read taxonomy from — a full guide, a lean doc, or a fixture. */
+type GuideLike = {
+  discipline?: string | null;
+  isSpecialty?: boolean | null;
+  category?: string | null;
+};
+
+/** Derive the orthogonal axes from a legacy `category` string. */
+export const categoryToAxes = (category?: string | null): GuideAxes => {
+  switch (category) {
+    case "design":
+      return { discipline: "design", isSpecialty: false };
+    case "codeSpeciality":
+      return { discipline: "code", isSpecialty: true };
+    case "designSpeciality":
+      return { discipline: "design", isSpecialty: true };
+    case "code":
+    default:
+      // Unknown/empty values fall back to the most common case.
+      return { discipline: "code", isSpecialty: false };
+  }
+};
+
+/** Build the legacy `category` string from the axes (the derived mirror). */
+export const axesToCategory = (
+  discipline: Discipline,
+  isSpecialty: boolean
+): string => {
+  if (discipline === "design") return isSpecialty ? "designSpeciality" : "design";
+  return isSpecialty ? "codeSpeciality" : "code";
+};
+
+/**
+ * Read a guide's discipline. Prefers the canonical `discipline` field and falls
+ * back to deriving from `category`, so this is correct whether or not a guide has
+ * been migrated.
+ */
+export const getDiscipline = (guide: GuideLike): Discipline =>
+  guide.discipline === "code" || guide.discipline === "design"
+    ? guide.discipline
+    : categoryToAxes(guide.category).discipline;
+
+/** Read whether a guide is a specialty guide (canonical field, else derived). */
+export const getIsSpecialty = (guide: GuideLike): boolean =>
+  typeof guide.isSpecialty === "boolean"
+    ? guide.isSpecialty
+    : categoryToAxes(guide.category).isSpecialty;
+
+export const isCodeGuide = (guide: GuideLike): boolean =>
+  getDiscipline(guide) === "code";
+
+/** Convenience for call sites that only have a legacy `category` string. */
+export const isCodeCategory = (category?: string | null): boolean =>
+  categoryToAxes(category).discipline === "code";
+
+export const isDesignGuide = (guide: GuideLike): boolean =>
+  getDiscipline(guide) === "design";

--- a/app/utils/publicGuideUtils.ts
+++ b/app/utils/publicGuideUtils.ts
@@ -9,6 +9,8 @@ export const createPublicGuideInfo = (guide: GuideType): GuideInfo => {
     title: guide.title,
     description: guide.description,
     category: guide.category,
+    discipline: (guide.discipline as "code" | "design") || undefined,
+    isSpecialty: guide.isSpecialty ?? undefined,
     order: guide.order,
     module: guide.module,
     // Add empty arrays for user-specific fields that the component expects

--- a/scripts/migrate-guide-taxonomy.mjs
+++ b/scripts/migrate-guide-taxonomy.mjs
@@ -1,0 +1,88 @@
+/**
+ * One-off backfill: populate the canonical taxonomy axes (`discipline`,
+ * `isSpecialty`) on every guide from the legacy `category` string.
+ *
+ * This is OPTIONAL — the app reads taxonomy through utils/guideTaxonomy, which
+ * falls back to deriving these from `category` when the fields are absent. Run it
+ * to make the new fields explicit in the DB (nicer for queries/consistency).
+ *
+ * Usage:
+ *   node scripts/migrate-guide-taxonomy.mjs           # apply
+ *   node scripts/migrate-guide-taxonomy.mjs --dry-run # report only
+ *
+ * Requires MONGODB_CONNECTION in .env.local (loaded below).
+ */
+import "dotenv/config";
+import { config } from "dotenv";
+import mongoose from "mongoose";
+
+// Prefer .env.local (Next's convention) if present.
+config({ path: ".env.local" });
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const categoryToAxes = (category) => {
+  switch (category) {
+    case "design":
+      return { discipline: "design", isSpecialty: false };
+    case "codeSpeciality":
+      return { discipline: "code", isSpecialty: true };
+    case "designSpeciality":
+      return { discipline: "design", isSpecialty: true };
+    case "code":
+    default:
+      return { discipline: "code", isSpecialty: false };
+  }
+};
+
+const run = async () => {
+  const uri = process.env.MONGODB_CONNECTION;
+  if (!uri) {
+    console.error("MONGODB_CONNECTION is not set (check .env.local).");
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  const guides = mongoose.connection.db.collection("guides");
+
+  const cursor = guides.find(
+    {},
+    { projection: { category: 1, discipline: 1, isSpecialty: 1 } }
+  );
+
+  let scanned = 0;
+  let updated = 0;
+
+  for await (const guide of cursor) {
+    scanned++;
+    const axes = categoryToAxes(guide.category);
+    const needsDiscipline = guide.discipline !== axes.discipline;
+    const needsSpecialty = guide.isSpecialty !== axes.isSpecialty;
+    if (!needsDiscipline && !needsSpecialty) continue;
+
+    updated++;
+    if (DRY_RUN) {
+      console.log(
+        `would update ${guide._id}: category=${guide.category} -> discipline=${axes.discipline}, isSpecialty=${axes.isSpecialty}`
+      );
+    } else {
+      await guides.updateOne(
+        { _id: guide._id },
+        { $set: { discipline: axes.discipline, isSpecialty: axes.isSpecialty } }
+      );
+    }
+  }
+
+  console.log(
+    `${DRY_RUN ? "[dry-run] " : ""}scanned ${scanned} guides, ${updated} ${
+      DRY_RUN ? "would be " : ""
+    }updated.`
+  );
+
+  await mongoose.disconnect();
+};
+
+run().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/types/guideTypes.ts
+++ b/types/guideTypes.ts
@@ -72,7 +72,11 @@ export type GuideInfo = {
   _id: Types.ObjectId;
   title: string;
   description: string;
+  /** Derived mirror of (discipline, isSpecialty); read via utils/guideTaxonomy. */
   category: string;
+  /** Canonical taxonomy axes (may be absent on un-migrated guides). */
+  discipline?: "code" | "design";
+  isSpecialty?: boolean;
   order: number;
   module: ModuleType;
 


### PR DESCRIPTION
Replace the conflated `category` enum as the source of truth with two orthogonal canonical fields, and document auto-graded guides in the in-app grading walkthrough.

- guide schema: add canonical discipline ("code"|"design") + isSpecialty; keep `category` as a derived mirror (written on save) for LTI/reports/the edit-list filter
- utils/guideTaxonomy: central helpers that read the axes and fall back to deriving from `category`, so the app is correct before any migration
- edit form authors discipline + specialty (was a 4-value dropdown); create route and getGuides/getPublicGuides projections updated
- StudentHomePage specialty/discipline grade logic routed through the helpers
- fix latent bug: RichTextEditor + GiveFeedbackView checked `category === 'speciality code'` (never matched codeSpeciality), so specialty-code guides showed design review tips — now use isCodeCategory()
- optional backfill: scripts/migrate-guide-taxonomy.mjs (supports --dry-run)
- GradingSlideshow: add a slide explaining auto-graded interactive exercises
- tests: __tests__/utils/guideTaxonomy.test.ts